### PR TITLE
HomeKit flow rate integration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -62,6 +62,12 @@
         "default": 0,
         "required": false
       },
+      "flowRateSensor": {
+        "type": "boolean",
+        "title": "${config.title.flowRateSensor}",
+        "description": "${config.description.flowRateSensor}",
+        "required": false
+      },
       "units": {
         "type": "string",
         "title": "${config.title.units}",
@@ -112,6 +118,7 @@
           "key": "flowThreshold",
           "type": "number"
         },
+        "flowRateSensor",
         "units",
         "disableDeviceLogging",
         "verbose",

--- a/src/homebridge/accessory.ts
+++ b/src/homebridge/accessory.ts
@@ -25,16 +25,19 @@ export class FlumeAccessory {
 
   private readonly leakService: Service;
   private readonly motionService?: Service;
+  private readonly flowRateService?: Service;
 
   private isLeakDetected: boolean = false;
   private isBatteryLow: boolean = false;
   private isDisconnected: boolean = true;
   private isFlowing: boolean = false;
+  private currentFlowRate: number = 0;
 
   private readonly charLeakDetected: typeof Characteristic.LeakDetected;
   private readonly charStatusLowBattery: typeof Characteristic.StatusLowBattery;
   private readonly charStatusFault: typeof Characteristic.StatusFault;
   private readonly charMotionDetected: typeof Characteristic.MotionDetected;
+  private readonly charCurrentAmbientLightLevel: typeof Characteristic.CurrentAmbientLightLevel;
 
   private readonly todayUsageChar: Characteristic;
   private readonly monthUsageChar: Characteristic;
@@ -65,6 +68,7 @@ export class FlumeAccessory {
     this.charStatusLowBattery = this.Characteristic.StatusLowBattery;
     this.charStatusFault = this.Characteristic.StatusFault;
     this.charMotionDetected = this.Characteristic.MotionDetected;
+    this.charCurrentAmbientLightLevel = this.Characteristic.CurrentAmbientLightLevel;
 
     this.leakService = this.accessory.getService(this.HAP.Service.LeakSensor)
       || this.accessory.addService(this.HAP.Service.LeakSensor);
@@ -75,11 +79,21 @@ export class FlumeAccessory {
         || this.accessory.addService(this.HAP.Service.MotionSensor);
     }
 
+    // Add optional LightSensor service for flow rate if configured
+    // This (ab)uses the light sensor's lux value to show flow rate in Apple Home
+    if (this.platform.config.flowRateSensor) {
+      this.flowRateService = this.accessory.getService(this.HAP.Service.LightSensor)
+        || this.accessory.addService(this.HAP.Service.LightSensor, strings.customChar.flowRate);
+    }
+
     this.isLeakDetected = this.leakService.getCharacteristic(this.charLeakDetected).value === this.charLeakDetected.LEAK_DETECTED;
     this.isBatteryLow = this.leakService.getCharacteristic(this.charStatusLowBattery).value === this.charStatusLowBattery.BATTERY_LEVEL_LOW;
     this.isDisconnected = this.leakService.getCharacteristic(this.charStatusFault).value === this.charStatusFault.GENERAL_FAULT;
     if (this.motionService) {
       this.isFlowing = this.motionService.getCharacteristic(this.charMotionDetected).value === true;
+    }
+    if (this.flowRateService) {
+      this.currentFlowRate = this.flowRateService.getCharacteristic(this.charCurrentAmbientLightLevel).value as number || 0;
     }
 
     this.clearCustomCharacteristics();
@@ -127,6 +141,16 @@ export class FlumeAccessory {
       this.isFlowing = this.device.isFlowing;
       this.motionService.updateCharacteristic(this.charMotionDetected, this.isFlowing);
       this.logState(this.isFlowing ? LogLevel.INFO : LogLevel.INFO, this.isFlowing ? strings.status.flowActive : strings.status.flowInactive);
+    }
+
+    // Update flow rate light sensor
+    // HomeKit LightSensor requires a minimum value of 0.0001 lux
+    if (this.flowRateService && this.device.currentFlowRate !== this.currentFlowRate) {
+      this.currentFlowRate = this.device.currentFlowRate;
+      // Use 0.0001 as minimum when flow rate is 0 (HomeKit requirement)
+      const luxValue = this.currentFlowRate > 0 ? this.currentFlowRate : 0.0001;
+      this.flowRateService.updateCharacteristic(this.charCurrentAmbientLightLevel, luxValue);
+      this.logState(LogLevel.INFO, `${strings.status.flowRate}: ${this.currentFlowRate.toFixed(2)} ${this.stringForUnits()}/min`);
     }
 
     this.todayUsageChar.updateValue(this.device.usageToday);

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -19,7 +19,8 @@ const overrides = {
       units: 'Volumeneinheiten, die für benutzerdefinierte Merkmale verwendet werden',
       verbose: 'Zusätzliche Debug-Protokollierung aktivieren',
       flowMotionSensor: 'Fügt einen Bewegungssensor hinzu, der aktiv ist, während Wasser fließt',
-      flowThreshold: 'Mindeständerung des Verbrauchs zwischen Abfragen, um fließendes Wasser zu erkennen (0 für jede Zunahme)'
+      flowThreshold: 'Mindeständerung des Verbrauchs zwischen Abfragen, um fließendes Wasser zu erkennen (0 für jede Zunahme)',
+      flowRateSensor: 'Fügt einen Lichtsensor hinzu, der die aktuelle Durchflussrate anzeigt (Wert als "lux" entspricht Einheiten/Minute)',
     },
 
     enumNames: {
@@ -41,7 +42,8 @@ const overrides = {
       username: 'Flume-Benutzername',
       verbose: 'Verbose',
       flowMotionSensor: 'Bewegungssensor für fließendes Wasser hinzufügen',
-      flowThreshold: 'Schwellenwert für Fluss'
+      flowThreshold: 'Schwellenwert für Fluss',
+      flowRateSensor: 'Durchflussratensensor hinzufügen',
     },
   },
 
@@ -49,6 +51,7 @@ const overrides = {
     lastMonth: 'Letzten Monat',
     monthUsage: 'Diesen Monat',
     todayUsage: 'Heute',
+    flowRate: 'Durchflussrate',
   },
 
   errors: {
@@ -84,7 +87,8 @@ const overrides = {
     leakDetected: 'Leck erkannt!',
     leakNotDetected: 'Keine Lecks festgestellt',
     flowActive: 'Wasser fließt',
-    flowInactive: 'Wasser fließt nicht'
+    flowInactive: 'Wasser fließt nicht',
+    flowRate: 'Durchflussrate',
   },
 };
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -16,7 +16,8 @@ const en = {
       useNotifications: 'If true, an unread usage alert notification will be considered a leak',
       verbose: 'Enable additional debug logging',
       flowMotionSensor: 'Adds a Motion Sensor accessory that is active while water is flowing',
-      flowThreshold: 'Minimum change in usage between polls to consider water flowing (0 to trigger on any increase)'
+      flowThreshold: 'Minimum change in usage between polls to consider water flowing (0 to trigger on any increase)',
+      flowRateSensor: 'Adds a Light Sensor showing current flow rate (value shown as "lux" represents units/minute)',
     },
 
     enumNames: {
@@ -39,7 +40,8 @@ const en = {
       username: 'Flume Username',
       verbose: 'Verbose',
       flowMotionSensor: 'Add Motion Sensor for Flowing Water',
-      flowThreshold: 'Flow Threshold'
+      flowThreshold: 'Flow Threshold',
+      flowRateSensor: 'Add Flow Rate Sensor',
     },
   },
   
@@ -47,6 +49,7 @@ const en = {
     lastMonth: 'Last Month',
     monthUsage: 'This Month',
     todayUsage: 'Today',
+    flowRate: 'Flow Rate',
   },
 
   errors: {
@@ -83,7 +86,8 @@ const en = {
     leakDetected: 'Leak detected!',
     leakNotDetected: 'No leaks detected',
     flowActive: 'Water is flowing',
-    flowInactive: 'Water is not flowing'
+    flowInactive: 'Water is not flowing',
+    flowRate: 'Flow rate',
   },
 };
 

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -314,7 +314,7 @@ export class FlumeAPI {
     return leakData;
   }
 
-  private async getUsageData(deviceId: string): Promise<Types.UsageData | null> {
+  private async getUsageData(deviceId: string, includeFlowRate: boolean = false): Promise<Types.UsageData | null> {
 
     // Generate dates for the query data
     const now = new Date();
@@ -325,32 +325,49 @@ export class FlumeAPI {
     const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
     const startOfLastMonth = `${lastMonth.getFullYear()}-${pad(lastMonth.getMonth() + 1)}-01 00:00:00`;
 
-    const data = {
-      queries: [
-        {
-          request_id: 'today',
-          bucket: 'DAY',
-          since_datetime: startOfToday,
-          operation: 'SUM',
-          units: this.config.units ?? Types.VolumeUnits.GALLONS,
-        },
-        {
-          request_id: 'month',
-          bucket: 'MON',
-          since_datetime: startOfCurrMonth,
-          operation: 'SUM',
-          units: this.config.units ?? Types.VolumeUnits.GALLONS,
-        },
-        {
-          request_id: 'lastMonth',
-          bucket: 'MON',
-          since_datetime: startOfLastMonth,
-          until_datetime: startOfCurrMonth,
-          operation: 'SUM',
-          units: this.config.units ?? Types.VolumeUnits.GALLONS,
-        },
-      ],
-    };
+    // For flow rate, query the last 5 minutes of minute-level data
+    const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
+    const flowRateSince = `${fiveMinutesAgo.getFullYear()}-${pad(fiveMinutesAgo.getMonth() + 1)}-${pad(fiveMinutesAgo.getDate())} ` +
+      `${pad(fiveMinutesAgo.getHours())}:${pad(fiveMinutesAgo.getMinutes())}:00`;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const queries: any[] = [
+      {
+        request_id: 'today',
+        bucket: 'DAY',
+        since_datetime: startOfToday,
+        operation: 'SUM',
+        units: this.config.units ?? Types.VolumeUnits.GALLONS,
+      },
+      {
+        request_id: 'month',
+        bucket: 'MON',
+        since_datetime: startOfCurrMonth,
+        operation: 'SUM',
+        units: this.config.units ?? Types.VolumeUnits.GALLONS,
+      },
+      {
+        request_id: 'lastMonth',
+        bucket: 'MON',
+        since_datetime: startOfLastMonth,
+        until_datetime: startOfCurrMonth,
+        operation: 'SUM',
+        units: this.config.units ?? Types.VolumeUnits.GALLONS,
+      },
+    ];
+
+    // Add flow rate query if enabled
+    if (includeFlowRate) {
+      queries.push({
+        request_id: 'flowRate',
+        bucket: 'MIN',
+        since_datetime: flowRateSince,
+        operation: 'SUM',
+        units: this.config.units ?? Types.VolumeUnits.GALLONS,
+      });
+    }
+
+    const data = { queries };
 
     const usageData = await this.do<Types.UsageData>(this.getUsageData.name, data, false, false, URL_WATER_USAGE, this.auth?.userId, deviceId);
 
@@ -370,9 +387,12 @@ export class FlumeAPI {
       let deviceData: Types.DeviceData | null = null;
       let usageData: Types.UsageData | null = null;
 
+      // Determine if we need flow rate data (minute-level query)
+      const needsFlowRate = this.config.flowRateSensor === true;
+
       if (Date.now() - this.lastFullRefresh > FULL_REFRESH_INTERVAL) {
         deviceData = await this.getDeviceData(id);
-        usageData = await this.getUsageData(id);
+        usageData = await this.getUsageData(id, needsFlowRate);
         this.lastFullRefresh = Date.now();
       }
 
@@ -385,9 +405,9 @@ export class FlumeAPI {
         leakData = await this.getLeakData(id);
       }
 
-      // If flow motion sensor is enabled, fetch usage data each sync to compute flow state
-      if (this.config.flowMotionSensor && !usageData) {
-        usageData = await this.getUsageData(id);
+      // If flow motion sensor or flow rate sensor is enabled, fetch usage data each sync
+      if ((this.config.flowMotionSensor || this.config.flowRateSensor) && !usageData) {
+        usageData = await this.getUsageData(id, needsFlowRate);
       }
 
       device.update(leakData, unreadNotifications, deviceData, usageData);

--- a/src/model/device.ts
+++ b/src/model/device.ts
@@ -18,6 +18,7 @@ export class Device {
   usageToday: number = 0;
   usageMonth: number = 0;
   usageLastMonth: number = 0;
+  currentFlowRate: number = 0; // units per minute (gallons/min, liters/min, etc.)
 
   private _onUpdateCallback: ((id: string) => void) | null = null;
 
@@ -55,6 +56,21 @@ export class Device {
 
       const usageIncrease = this.usageToday - previousUsageToday;
       this.isFlowing = usageIncrease > this.flowThreshold;
+
+      // Calculate current flow rate from minute-level data
+      if (usageData.flowRate && usageData.flowRate.length > 0) {
+        // Get the most recent minute's usage as the current flow rate
+        // The flowRate array contains per-minute usage values
+        const recentMinutes = usageData.flowRate;
+        if (recentMinutes.length > 0) {
+          // Use the most recent minute's value, or average the last few minutes
+          // Taking the last value gives the most current reading
+          const lastMinute = recentMinutes[recentMinutes.length - 1];
+          this.currentFlowRate = lastMinute?.value || 0;
+        } else {
+          this.currentFlowRate = 0;
+        }
+      }
     }
 
     if (this._onUpdateCallback) {

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -35,6 +35,7 @@ export type FlumeConfig = PlatformConfig & {
   verbose: boolean,
   flowMotionSensor?: boolean,
   flowThreshold?: number,
+  flowRateSensor?: boolean,
 }
 
 export type TokenData = {
@@ -71,6 +72,7 @@ export type UsageData = {
   today: {value: number}[];
   month: {value: number}[];
   lastMonth: {value: number}[];
+  flowRate?: {datetime: string, value: number}[];
 };
 
 export type JwtPayload = {


### PR DESCRIPTION
Add a current water flow rate sensor to HomeKit, displayed via a Light Sensor service.

This feature leverages minute-level data from the Flume API to calculate the current flow rate. It uses a HomeKit Light Sensor service as a workaround to display the numeric flow rate value directly within the Apple Home app, as custom characteristics are not natively supported there.

---
<a href="https://cursor.com/background-agent?bcId=bc-52e785ac-3de5-41c7-b6bd-bd5cb0379b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52e785ac-3de5-41c7-b6bd-bd5cb0379b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

